### PR TITLE
Unexpected body lengths result in exceptions

### DIFF
--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,0 +1,14 @@
+<p>This extension extract metadata present in image files. The information found is rarely critical, but it can be useful for general reconnaissance. These information can be usernames who created the files, local paths and technologies used.</p>
+
+<p><b>Metadata type supported</b></p>
+<ul>
+    <li>JPEG Exif (using the library metadata-extractor)</li>
+    <li>PNG Text chunks (using the library PNGJ)</li>
+</ul>
+
+<p><b>Usage</b></p>
+<ul>
+    <li>Go to: Proxy &gt; History</li>
+    <li>Select a request that loads an image</li>
+    <li>The metadata can be found under: Response &gt; Metadata</li>
+</ul>

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,0 +1,11 @@
+Uuid: 3996aa01e0474b1a990db586a7f14ab7
+ExtensionType: 1
+Name: Image Metadata
+ScreenVersion: 2.1.0
+SerialVersion: 2
+MinPlatformVersion: 0
+ProOnly: False
+Author: Philippe Arteau
+ShortDescription: Extracts metadata from image files.
+EntryPoint: img-metadata-burp-plugin/target/img-metadata-burp-plugin-2.jar
+BuildCommand: rm -f libs/zap.jar && mvn package -DskipTests=true -Dmaven.javadoc.skip=true -B -Pburp-only

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: 3996aa01e0474b1a990db586a7f14ab7
 ExtensionType: 1
 Name: Image Metadata
 ScreenVersion: 2.1.1
-SerialVersion: 4
+SerialVersion: 5
 MinPlatformVersion: 0
 ProOnly: False
 Author: Philippe Arteau

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: 3996aa01e0474b1a990db586a7f14ab7
 ExtensionType: 1
 Name: Image Metadata
 ScreenVersion: 2.1.1
-SerialVersion: 3
+SerialVersion: 4
 MinPlatformVersion: 0
 ProOnly: False
 Author: Philippe Arteau

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,7 +1,7 @@
 Uuid: 3996aa01e0474b1a990db586a7f14ab7
 ExtensionType: 1
 Name: Image Metadata
-ScreenVersion: 2.1.0
+ScreenVersion: 2.1.1
 SerialVersion: 2
 MinPlatformVersion: 0
 ProOnly: False

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: 3996aa01e0474b1a990db586a7f14ab7
 ExtensionType: 1
 Name: Image Metadata
 ScreenVersion: 2.1.1
-SerialVersion: 2
+SerialVersion: 3
 MinPlatformVersion: 0
 ProOnly: False
 Author: Philippe Arteau

--- a/img-metadata-core/src/main/java/com/h3xstream/imgmetadata/MetadataExtractor.java
+++ b/img-metadata-core/src/main/java/com/h3xstream/imgmetadata/MetadataExtractor.java
@@ -85,6 +85,8 @@ public class MetadataExtractor {
     // - http://www.astro.keele.ac.uk/oldusers/rno/Computing/File_magic.html
 
     public static boolean isJpgFile(byte[] respBytes,int bodyOffset) {
+        if (respBytes.length < bodyOffset + 3) return false;
+
         return ((respBytes[bodyOffset] == (byte) 0xFF && //
                 respBytes[bodyOffset+1] == (byte) 0xD8) //JPEG
                 || (respBytes[bodyOffset] == (byte) 0x4A && //
@@ -98,6 +100,8 @@ public class MetadataExtractor {
     }
 
     public static boolean isPngFile(byte[] respBytes,int bodyOffset) {
+        if (respBytes.length < bodyOffset + 7) return false;
+
         return respBytes[bodyOffset] == (byte) 0x89 && //
                 respBytes[bodyOffset+1] == (byte) 0x50 && //
                 respBytes[bodyOffset+2] == (byte) 0x4E && //
@@ -109,6 +113,8 @@ public class MetadataExtractor {
     }
 
     public static boolean isGifFile(byte[] respBytes,int bodyOffset) {
+        if (respBytes.length < bodyOffset + 3) return false;
+
         return respBytes[bodyOffset] == (byte) 0x47 && //
                 respBytes[bodyOffset+1] == (byte) 0x49 && //
                 respBytes[bodyOffset+2] == (byte) 0x46 && //
@@ -116,6 +122,8 @@ public class MetadataExtractor {
     }
 
     public static boolean isBmpFile(byte[] respBytes,int bodyOffset) {
+        if (respBytes.length < bodyOffset + 1) return false;
+
         return respBytes[bodyOffset] == (byte) 0x42 && //
                 respBytes[bodyOffset+1] == (byte) 0x4d;
     }


### PR DESCRIPTION
These can be guarded against when testing whether the images are of specific types.